### PR TITLE
fix: rating 승패 로직 변경

### DIFF
--- a/server/models/Users.js
+++ b/server/models/Users.js
@@ -34,6 +34,21 @@ const usersModel = (Sequelize, DataTypes) => {
                 allowNull: false,
                 defaultValue: 0,
             },
+            win: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+            lose: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+            rating: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
             // true:온라인, false:오프라인
             connecting: {
                 type: DataTypes.BOOLEAN,

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -12,14 +12,14 @@ router.get("/", mainCtr.index);
 /**
  * @swagger
  * paths:
- *  /api-server/patchPoint:
+ *  /api-server/matchResult:
  *    patch:
- *      summary: "유저 포인트 변경"
- *      description: " 1: 승리 시 승점 +, 0: 패배 시 승점 -"
+ *      summary: "게임 종료 후 승패 처리"
+ *      description: " 1: 승리 시, 0: 패배 시"
  *      tags: [rank]
  *      responses:
  *        "200":
- *          description: 게임 종료 후 승패에 따라 유저 포인트 변경
+ *          description: 게임 종료 후 승패에 따라 데이터 처리
  *          content:
  *            application/json:
  *              schema:
@@ -33,11 +33,11 @@ router.get("/", mainCtr.index);
  *                          [
  *{
     "result": true,
-    "msg": "포인트가 변경되었습니다."
+    "msg": "승리 유저 정보가 변경되었습니다."
 }
  *                          ]
  */
-router.patch("/patchPoint", mainCtr.patchPoint);
+router.patch("/matchResult", mainCtr.matchResult);
 
 /**
  * @swagger

--- a/server/sql/users.sql
+++ b/server/sql/users.sql
@@ -1,36 +1,35 @@
--- Active: 1707101283311@@127.0.0.1@3306@tetrist
 desc users;
 
 select * from users;
 
 INSERT INTO
     users (
-        user_id, email, password, nickname, point, custom, connecting, chat_penalty, access_penalty
+        user_id, email, password, nickname, point, custom, win, lose, rating, connecting, chat_penalty, access_penalty
     )
 VALUES (
-        1, "user1@test.com", "user1234!", "유저1", 1000, '{"profile":1, "profileEdge":2, "theme":3}', true, true, false
+        1, "user1@test.com", "user1234!", "유저1", 1000, '{"profile":1, "profileEdge":2, "theme":3}', 1, 3, 100, true, true, false
     );
 
 INSERT INTO
     users (
-        user_id, email, password, nickname, point, custom, connecting, chat_penalty, access_penalty
+        user_id, email, password, nickname, point, custom, win, lose, rating, connecting, chat_penalty, access_penalty
     )
 VALUES (
-        2, "user2@test.com", "user1234", "유저2", 2000, '{"profile":1, "profileEdge":2, "theme":3}', false, false, true
+        2, "user2@test.com", "user1234", "유저2", 2000, '{"profile":1, "profileEdge":2, "theme":3}', 0, 0, 0, false, false, true
     );
 
 INSERT INTO
     users (
-        user_id, email, password, nickname, point, custom, connecting, chat_penalty, access_penalty
+        user_id, email, password, nickname, point, custom, win, lose, rating, connecting, chat_penalty, access_penalty
     )
 VALUES (
-        3, "user3@test.com", "user3pw", "유저3", 3000, '{"profile":1, "profileEdge":2, "theme":3}', true, false, false
+        3, "user3@test.com", "user3pw", "유저3", 3000, '{"profile":1, "profileEdge":2, "theme":3}', 10, 2, 500, true, false, false
     );
 
 INSERT INTO
     users (
-        user_id, email, password, nickname, point, custom, connecting, chat_penalty, access_penalty
+        user_id, email, password, nickname, point, custom, win, lose, rating, connecting, chat_penalty, access_penalty
     )
 VALUES (
-        4, "user4@test.com", "user4pw", "유저4", 4000, '{"profile":1, "profileEdge":2, "theme":3}', false, false, false
+        4, "user4@test.com", "user4pw", "유저4", 4000, '{"profile":1, "profileEdge":2, "theme":3}', 100, 100, 700, false, false, false
     );


### PR DESCRIPTION
### controller/Cmain
- 함수명 변경
- 승패 로직 수정
  - 단순 포인트만 처리 -> 승리 수와 패배 수, 승점, 상점 포인트를 분리해서 처리
  - 서버에서 승패에 따른 포인트를 입력
  - 포인트를 프론트에서 지정할 경우도 주석 상태로 추가

### models/User
- win, lose, rating 속성 추가

### routes/router
- 라우터 경로명 변경

### sql/users
- 변경된 속성에 맞춰 데이터 수정