### PR TITLE
feat: 관리자 페이지 수정

### DIFF
--- a/server/admin/adminLogin.ejs
+++ b/server/admin/adminLogin.ejs
@@ -7,11 +7,6 @@
         <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     </head>
     <style>
-        body {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
         .loginform {
             display: flex;
             flex-direction: column;
@@ -48,6 +43,11 @@
         </div>
     </body>
     <script>
+        const fromNoAuth = JSON.parse("<%-fromNoAuth%>");
+        if (fromNoAuth === true) {
+            alert("권한이 없습니다. 먼저 관리자 계정으로 로그인하세요.");
+        }
+
         const form = document.forms["login"];
         const message = document.querySelector(".message");
         function adminLogin() {

--- a/server/admin/adminPage.ejs
+++ b/server/admin/adminPage.ejs
@@ -7,11 +7,49 @@
             h2 {
                 text-align: center;
             }
+            .list {
+                display: flex;
+                flex-direction: column;
+                text-align: center;
+            }
         </style>
         <title>tetrist 관리자 페이지</title>
     </head>
     <%- include('header')%>
     <body>
         <h2>관리자 페이지</h2>
+        <br />
+        <div class="list">
+            <label>
+                <a href="/api-server/admin/adminUser"
+                    >[유저 관리 페이지로 이동]</a
+                >
+                <p>
+                    가입된 모든 유저의 정보를 확인할 수 있으며, 관리자 권한으로
+                    유저 닉네임 수정, 유저 접속 제재, 유저 비밀번호 초기화, 유저
+                    정보 삭제가 가능합니다.
+                </p>
+            </label>
+            <br />
+            <label>
+                <a href="/api-server/admin/adminRoom"
+                    >[게임룸 관리 페이지로 이동]</a
+                >
+                <p>
+                    현재 생성되어 있는 방의 정보를 확인할 수 있으며, 관리자
+                    권한으로 방을 삭제할 수 있습니다.
+                </p>
+            </label>
+            <br />
+            <label>
+                <a href="/api-server/admin/adminSuggestion"
+                    >[유저 건의 사항으로 이동]</a
+                >
+                <p>
+                    유저가 전송한 건의사항을 열람할 수 있으며, 확인 완료한
+                    건의는 확인 칸에 체크하여 분리하여 열람할 수 있습니다.
+                </p>
+            </label>
+        </div>
     </body>
 </html>

--- a/server/admin/adminRoom.ejs
+++ b/server/admin/adminRoom.ejs
@@ -7,11 +7,6 @@
         <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     </head>
     <style>
-        body {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
         .roomTable {
             text-align: center;
         }

--- a/server/admin/adminSuggestion.ejs
+++ b/server/admin/adminSuggestion.ejs
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="ko">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>tetrist 관리자 페이지</title>
+        <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    </head>
+    <style>
+        details {
+            width: 70vw;
+        }
+        summary {
+            margin: 10px -10px;
+            padding: 5px;
+            font-size: 20px;
+            font-weight: bold;
+        }
+        .checked_x {
+            background-color: rgb(225, 247, 235);
+        }
+        .checked_o {
+            background-color: rgb(206, 207, 207);
+        }
+
+        p {
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
+
+        span {
+            font-weight: bold;
+            display: inline-block;
+            width: 100%;
+            text-align: right;
+        }
+        input {
+            width: 20px;
+            height: 20px;
+        }
+    </style>
+    <%- include('header')%>
+    <body>
+        <h2>건의사항 확인</h2>
+        <div class="sugs">
+            <% for (let i= 0; i < data.length; i++) { %> <%if
+            (!data[i].sug_checked) {%>
+            <details id="d_<%= data[i].sug_id %>">
+                <summary class="checked_x"><%= data[i].sug_title %></summary>
+                <p>유저 인덱스: <%= data[i].user_id %></p>
+                <p>건의 날짜: <%= data[i].updatedAt %></p>
+                <p class="s_content">건의 내용: <%= data[i].sug_content %></p>
+                <br />
+                <span>
+                    확인 <input type="checkbox" id="checkbox_<%= data[i].sug_id
+                    %>" <%= data[i].sug_checked ? "checked" : "" %>
+                    onclick="patchSugCheck('<%= data[i].sug_id %>')"/>
+                </span>
+            </details>
+            <%}%> <%}%>
+        </div>
+        <h3>확인 완료</h3>
+        <div class="sugs">
+            <% for (let i= 0; i < data.length; i++) { %> <%if
+            (data[i].sug_checked) {%>
+            <details id="d_<%= data[i].sug_id %>">
+                <summary class="checked_o"><%= data[i].sug_title %></summary>
+                <p>유저 인덱스: <%= data[i].user_id %></p>
+                <p>건의 날짜: <%= data[i].updatedAt %></p>
+                <p>건의 내용: <%= data[i].sug_content %></p>
+                <br />
+                <span>
+                    확인 <input type="checkbox" id="checkbox_<%= data[i].sug_id
+                    %>" <%= data[i].sug_checked ? "checked" : "" %>
+                    onclick="patchSugCheck('<%= data[i].sug_id %>')"/>
+                </span>
+            </details>
+            <%}%> <%}%>
+        </div>
+    </body>
+    <script>
+        const patchSugCheck = (sugId) => {
+            const isChecked = document.getElementById(
+                `checkbox_${sugId}`
+            ).checked;
+            console.log(sugId, isChecked);
+            axios({
+                method: "PATCH",
+                url: "/api-server/admin/checkSug",
+                data: { sugId, isChecked },
+            })
+                .then((res) => {
+                    alert("건의사항 확인 여부가 변경되었습니다.");
+                    document.location.href =
+                        "/api-server/admin/adminSuggestion";
+                })
+                .catch((err) => {
+                    console.log(err);
+                    alert(err.response.data.msg);
+                });
+        };
+    </script>
+</html>

--- a/server/admin/adminUser.ejs
+++ b/server/admin/adminUser.ejs
@@ -8,11 +8,6 @@
     </head>
     <%- include('header')%>
     <style>
-        body {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
         .userTable {
             text-align: center;
         }
@@ -29,13 +24,13 @@
                         <th>인덱스</th>
                         <th>이메일</th>
                         <th>닉네임</th>
+                        <th>닉네임 변경</th>
                         <th>승리 수</th>
                         <th>패배 수</th>
                         <th>승점</th>
                         <th>제재 상태</th>
                         <th>비밀번호 초기화</th>
                         <th>유저 정보 삭제</th>
-                        <th>변경 사항 적용</th>
                     </tr>
                 </thead>
                 <tbody id="userList">
@@ -53,11 +48,19 @@
                                 id="<%= data[i].user_id %>_nick"
                             />
                         </td>
+                        <td>
+                            <button onclick="applyNick('<%=data[i].user_id%>')">
+                                적용
+                            </button>
+                        </td>
                         <td><%= data[i].win %></td>
                         <td><%= data[i].lose %></td>
                         <td><%= data[i].rating %></td>
                         <td>
-                            <select id="<%= data[i].user_id %>_penal">
+                            <select
+                                id="<%= data[i].user_id %>_penal"
+                                onchange="setPenalty('<%=data[i].user_id%>', this.value)"
+                            >
                                 <%if(!data[i].access_penalty){%>
                                 <option value="false" selected>없음</option>
                                 <option value="true">접속제재</option>
@@ -79,11 +82,6 @@
                                 삭제
                             </button>
                         </td>
-                        <td>
-                            <button onclick="apply('<%=data[i].user_id%>')">
-                                적용
-                            </button>
-                        </td>
                     </tr>
                     <%}%> <%}%>
                 </tbody>
@@ -91,9 +89,8 @@
         </div>
     </body>
     <script>
-        const apply = (userId) => {
+        const applyNick = (userId) => {
             const nickname = document.getElementById(`${userId}_nick`).value;
-            const penalty = document.getElementById(`${userId}_penal`).value;
             if (
                 confirm(
                     "유저 정보를 수정하시겠습니까? 수정된 정보는 복구할 수 없습니다."
@@ -101,8 +98,8 @@
             ) {
                 axios({
                     method: "PATCH",
-                    url: "/api-server/admin/patchUser",
-                    data: { userId, penalty, nickname },
+                    url: "/api-server/admin/patchUserNick",
+                    data: { userId, nickname },
                 })
                     .then((res) => {
                         alert("유저 정보가 수정되었습니다.");
@@ -147,6 +144,25 @@
                 })
                     .then((res) => {
                         alert("유저 비밀번호가 초기화되었습니다.");
+                        document.location.href = "/api-server/admin/adminUser";
+                    })
+                    .catch((err) => {
+                        console.log(err);
+                        alert(err.response.data.msg);
+                    });
+            }
+        };
+
+        const setPenalty = (userId, penalVal) => {
+            const penalty = JSON.parse(penalVal);
+            if (confirm("해당 유저의 제재 상태를 변경하시겠습니까?")) {
+                axios({
+                    method: "PATCH",
+                    url: "/api-server/admin/patchUserPenal",
+                    data: { userId, penalty },
+                })
+                    .then((res) => {
+                        alert("제재 상태가 변경되었습니다.");
                         document.location.href = "/api-server/admin/adminUser";
                     })
                     .catch((err) => {

--- a/server/admin/header.ejs
+++ b/server/admin/header.ejs
@@ -1,13 +1,18 @@
 <style>
+    body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
     header {
-        width: 90vw;
+        width: 90%;
         display: flex;
         flex-direction: row;
         justify-content: space-between;
         padding: 40px;
+        margin: 0 auto;
     }
     .link {
-        width: 30%;
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -17,21 +22,24 @@
         text-decoration: none;
         font-size: 1.3rem;
         font-weight: bold;
+        margin: 0 5px;
     }
     a:hover {
-        color: #006435;
+        color: #078f4b;
     }
 
     a:active {
-        color: #006435;
+        color: #078f4b;
     }
 </style>
 <header>
     <div class="link">
-        <a href="/api-server/admin/adminUser">유저 관리 페이지</a>
-        <a href="/api-server/admin/adminRoom">게임룸 관리 페이지</a>
+        <a href="/api-server/admin/adminPage">[홈]</a>
+        <a href="/api-server/admin/adminUser">[유저 관리 페이지]</a>
+        <a href="/api-server/admin/adminRoom">[게임룸 관리 페이지]</a>
+        <a href="/api-server/admin/adminSuggestion">[유저 건의 사항]</a>
     </div>
     <div class="logout">
-        <a href="/api-server/admin/logout">로그아웃</a>
+        <a href="/api-server/admin/logout">[로그아웃]</a>
     </div>
 </header>

--- a/server/admin/utils.js
+++ b/server/admin/utils.js
@@ -5,10 +5,7 @@ function checkAdmin(req, res, next) {
         next();
     } else {
         // 일반 유저
-        res.status(403).send(`<script>
-        alert('권한이 없습니다.')
-        document.location.href = "http://52.78.163.112/login";
-        </script>`);
+        res.render("adminLogin", { fromNoAuth: true });
     }
 }
 

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -8,6 +8,12 @@ const development = {
     database: process.env.DB_DATABASE,
     host: "127.0.0.1",
     dialect: "mysql",
+    dialectOptions: {
+        charset: "utf8mb4",
+        dateStrings: true,
+        typeCast: true,
+    }, // 날짜 표기 방식을 연-월-일 시:분:초 만 출력되도록 변경
+    timezone: "+09:00", // 표준시 보정
 };
 // rds 기준
 const production = {
@@ -16,6 +22,12 @@ const production = {
     database: process.env.RDS_DATABASE,
     host: process.env.RDS_HOST,
     dialect: "mysql",
+    dialectOptions: {
+        charset: "utf8mb4",
+        dateStrings: true,
+        typeCast: true,
+    },
+    timezone: "+09:00",
 };
 
 module.exports = { development, production };

--- a/server/controller/Cadmin.js
+++ b/server/controller/Cadmin.js
@@ -1,9 +1,14 @@
 const bcrypt = require("bcrypt");
-const { usersModel, roomsModel, productsModel } = require("../models");
+const {
+    usersModel,
+    roomsModel,
+    productsModel,
+    suggestionsModel,
+} = require("../models");
 
 // 렌더링
 exports.toLogin = (req, res) => {
-    res.render("adminLogin");
+    res.render("adminLogin", { fromNoAuth: false });
 };
 exports.toAdmin = (req, res) => {
     res.render("adminPage");
@@ -30,6 +35,15 @@ exports.toShop = async (req, res) => {
     try {
         const productList = await productsModel.findAll();
         res.render("adminShop", { data: productList });
+    } catch (error) {
+        console.log("error", error);
+        res.status(500).send("server error");
+    }
+};
+exports.toSug = async (req, res) => {
+    try {
+        const sugList = await suggestionsModel.findAll();
+        res.render("adminSuggestion", { data: sugList });
     } catch (error) {
         console.log("error", error);
         res.status(500).send("server error");
@@ -123,9 +137,9 @@ exports.deleteUser = async (req, res) => {
     }
 };
 
-exports.patchUser = async (req, res) => {
+exports.patchUserNick = async (req, res) => {
     try {
-        const { userId, nickname, penalty } = req.body;
+        const { userId, nickname } = req.body;
 
         const checkDupNick = await usersModel.findOne({
             where: {
@@ -142,7 +156,6 @@ exports.patchUser = async (req, res) => {
         const isUpdated = await usersModel.update(
             {
                 nickname: nickname,
-                access_penalty: penalty,
             },
             {
                 where: {
@@ -160,6 +173,38 @@ exports.patchUser = async (req, res) => {
             res.status(400).send({
                 result: false,
                 msg: "유저 정보가 수정되지 않았습니다.",
+            });
+        }
+    } catch (error) {
+        console.log("error", error);
+        res.status(500).send("server error");
+    }
+};
+exports.patchUserPenal = async (req, res) => {
+    try {
+        const { userId, penalty } = req.body;
+        console.log(req.body);
+
+        const isUpdated = await usersModel.update(
+            {
+                access_penalty: penalty,
+            },
+            {
+                where: {
+                    user_id: userId,
+                },
+            }
+        );
+
+        if (isUpdated > 0) {
+            res.status(200).send({
+                result: true,
+                msg: "제재 상태가 변경되었습니다.",
+            });
+        } else {
+            res.status(400).send({
+                result: false,
+                msg: "제재 상태가 변경되지 않았습니다.",
             });
         }
     } catch (error) {
@@ -223,6 +268,41 @@ exports.deleteRoom = async (req, res) => {
             res.status(400).send({
                 result: false,
                 msg: "삭제 요청을 처리할 수 없습니다.",
+            });
+        }
+    } catch (error) {
+        console.log("error", error);
+        res.status(500).send("server error");
+    }
+};
+
+// 건의사항 관리
+
+exports.checkSug = async (req, res) => {
+    try {
+        const { sugId, isChecked } = req.body;
+        console.log(req.body);
+
+        const isUpdated = await suggestionsModel.update(
+            {
+                sug_checked: isChecked,
+            },
+            {
+                where: {
+                    sug_id: sugId,
+                },
+            }
+        );
+
+        if (isUpdated > 0) {
+            res.status(200).send({
+                result: true,
+                msg: "건의사항 확인 여부가 변경되었습니다.",
+            });
+        } else {
+            res.status(400).send({
+                result: false,
+                msg: "건의사항 확인 여부가 변경되지 않았습니다.",
             });
         }
     } catch (error) {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -9,14 +9,18 @@ router.get("/adminPage", checkAdmin, adminCtr.toAdmin);
 router.get("/adminUser", checkAdmin, adminCtr.toUser);
 router.get("/adminRoom", checkAdmin, adminCtr.toRoom);
 router.get("/adminShop", checkAdmin, adminCtr.toShop);
+router.get("/adminSuggestion", checkAdmin, adminCtr.toSug);
 
 router.post("/login", adminCtr.adminLogin);
 router.get("/logout", checkAdmin, adminCtr.adminLogout);
 
 router.delete("/deleteUser/:userId", checkAdmin, adminCtr.deleteUser);
-router.patch("/patchUser", checkAdmin, adminCtr.patchUser);
+router.patch("/patchUserNick", checkAdmin, adminCtr.patchUserNick);
+router.patch("/patchUserPenal", checkAdmin, adminCtr.patchUserPenal);
 router.patch("/resetPw", checkAdmin, adminCtr.resetPw);
 
 router.delete("/deleteRoom/:roomId", checkAdmin, adminCtr.deleteRoom);
+
+router.patch("/checkSug", adminCtr.checkSug);
 
 module.exports = router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -338,7 +338,7 @@ authRouter.get("/logout", checkAuth, usersCtr.logout);
  *                  result: false
  *                  msg: "유저 정보를 찾을 수 없습니다."
  */
-authRouter.get("/mypage", checkAuth, usersCtr.getOneUser);
+authRouter.get("/mypage", checkAuth, /* checkPenalty, */ usersCtr.getOneUser);
 
 /**
  * @swagger
@@ -390,6 +390,7 @@ authRouter.get("/mypage", checkAuth, usersCtr.getOneUser);
 authRouter.patch(
     "/mypage/changePassword",
     checkAuth,
+    /* checkPenalty, */
     usersCtr.patchUserPassword
 );
 
@@ -443,6 +444,7 @@ authRouter.patch(
 authRouter.patch(
     "/mypage/changeNickname",
     checkAuth,
+    /* checkPenalty, */
     usersCtr.patchUserNickname
 );
 
@@ -497,7 +499,12 @@ authRouter.patch(
  *                  msg: "유저 정보가 수정되지 않았습니다."
  *
  */
-authRouter.patch("/mypage/changeCustom", checkAuth, usersCtr.patchCustom);
+authRouter.patch(
+    "/mypage/changeCustom",
+    checkAuth,
+    /* checkPenalty, */
+    usersCtr.patchCustom
+);
 
 /**
  * @swagger
@@ -538,6 +545,11 @@ authRouter.patch("/mypage/changeCustom", checkAuth, usersCtr.patchCustom);
  *                  msg: "탈퇴 요청을 처리할 수 없습니다."
  *
  */
-authRouter.delete("/mypage/delete", checkAuth, usersCtr.deleteUserData);
+authRouter.delete(
+    "/mypage/delete",
+    checkAuth,
+    /* checkPenalty, */
+    usersCtr.deleteUserData
+);
 
 module.exports = authRouter;

--- a/server/utils/routerUtils.js
+++ b/server/utils/routerUtils.js
@@ -19,7 +19,7 @@ function checkAuth(req, res, next) {
 async function checkPenalty(req, res, next) {
     const findUserData = await usersModel.findOne({
         where: {
-            email: req.body.email,
+            user_id: req.session.userId,
         },
     });
     if (!findUserData.access_penalty) {


### PR DESCRIPTION
 - 건의사항 조회 페이지 추가
   - 건의 제목 클릭 시 건의한 유저 인덱스, 날짜, 내용, 확인 칸이 펼쳐지도록
   - 확인 체크 시 확인 완료한 건의로 목록 분리
   - 날짜 표기 방식 수정
   - 헤더 링크 추가
  - 관리자 메인 페이지에 설명 추가
    - 헤더 링크 추가
  - 유저 관리 페이지에서 닉네임 변경과 제재 상태 변경 컨트롤러 분리
    - 제재상태만 변경할 시 닉네임 중복 검사로 인해 변경이 안되는 문제를 수정
 - 관리자 권한 확인 유틸 로직 변경
   - 배포서버 일반 로그인 페이지로 리다이렉트 > 관리자 로그인 페이지로 리다이렉트 & alert를 로그인 페이지에서 처리
 - 그 외
   - 클라이언트에서 처리되지 않는 유틸 주석 처리